### PR TITLE
Expand Playwright tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# UAPI
-This contains all work related to Automation of UAPI
+# UAPI Test Suite
+
+This repository contains Playwright tests written in TypeScript for the UAPI application.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+
+2. Set environment variables before running the tests (defaults shown below):
+   ```bash
+   export UAPI_BASE_URL="https://qc.uapi.sa"
+   export UAPI_USERNAME="fewer001"
+   export UAPI_PASSWORD="V@iolaptop1234"
+   ```
+
+## Running Tests
+
+Execute all tests using:
+```bash
+npx playwright test
+```
+
+## Notes
+
+- The module tests in `tests/modules.spec.ts` iterate over multiple modules such as `Users`, `Reports`, `Settings`, `Admin`, and `Projects`. Update the menu text and selectors to match your application.
+- Ensure network access to reach `https://qc.uapi.sa` when running the tests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "uapi",
+  "version": "1.0.0",
+  "description": "This contains all work related to Automation of UAPI",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.41.2",
+    "typescript": "^5.0.4"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/pages/BasePage.ts
+++ b/pages/BasePage.ts
@@ -1,0 +1,9 @@
+import { Page } from '@playwright/test';
+
+export default class BasePage {
+  protected readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+}

--- a/pages/DashboardPage.ts
+++ b/pages/DashboardPage.ts
@@ -1,0 +1,18 @@
+import { expect, Page } from '@playwright/test';
+import BasePage from './BasePage';
+
+export default class DashboardPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async openModule(menuText: string) {
+    await this.page.click(`text=${menuText}`);
+    await expect(this.page).toHaveURL(/.+/);
+  }
+
+  async logout() {
+    await this.page.click('text=Logout');
+    await expect(this.page).toHaveURL(/login/);
+  }
+}

--- a/pages/LoginPage.ts
+++ b/pages/LoginPage.ts
@@ -1,0 +1,22 @@
+import { Page } from '@playwright/test';
+import BasePage from './BasePage';
+
+export default class LoginPage extends BasePage {
+  
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async login(username: string, password: string) {
+    await this.page.fill('input[name="username"]', username);
+    await this.page.fill('input[name="password"]', password);
+    await Promise.all([
+      this.page.waitForNavigation(),
+      this.page.click('button[type="submit"]'),
+    ]);
+  }
+}

--- a/pages/modules/ModulePage.ts
+++ b/pages/modules/ModulePage.ts
@@ -1,0 +1,15 @@
+import { expect, Page } from '@playwright/test';
+import BasePage from '../BasePage';
+
+export default class ModulePage extends BasePage {
+  private readonly identifier: string;
+
+  constructor(page: Page, identifier: string) {
+    super(page);
+    this.identifier = identifier;
+  }
+
+  async isLoaded() {
+    await expect(this.page.locator(this.identifier)).toBeVisible();
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  use: {
+    baseURL: process.env.UAPI_BASE_URL || 'https://qc.uapi.sa',
+    headless: true,
+  },
+  testDir: './tests',
+  timeout: 60 * 1000,
+};
+
+export default config;

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+import LoginPage from '../pages/LoginPage';
+
+test.describe('UAPI Login', () => {
+  test('should login successfully', async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(process.env.UAPI_USERNAME!, process.env.UAPI_PASSWORD!);
+    await expect(page).toHaveURL(/dashboard/);
+  });
+});

--- a/tests/logout.spec.ts
+++ b/tests/logout.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import LoginPage from '../pages/LoginPage';
+import DashboardPage from '../pages/DashboardPage';
+
+/** Basic logout test after a successful login. */
+
+test('user can log out', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login(process.env.UAPI_USERNAME!, process.env.UAPI_PASSWORD!);
+  const dashboard = new DashboardPage(page);
+  await dashboard.logout();
+});

--- a/tests/modules.spec.ts
+++ b/tests/modules.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import LoginPage from '../pages/LoginPage';
+import DashboardPage from '../pages/DashboardPage';
+import ModulePage from '../pages/modules/ModulePage';
+
+/**
+ * Example tests for several modules after login.
+ * Replace selectors and menu text with real ones from the application.
+ */
+
+test.describe('UAPI Modules', () => {
+  test.beforeEach(async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(process.env.UAPI_USERNAME!, process.env.UAPI_PASSWORD!);
+    await expect(page).toHaveURL(/dashboard/);
+  });
+
+  const modules = [
+    { name: 'Users', selector: '#users-table' },
+    { name: 'Reports', selector: '#reports-list' },
+    { name: 'Settings', selector: '#settings-panel' },
+    { name: 'Admin', selector: '#admin-panel' },
+    { name: 'Projects', selector: '#projects-board' },
+  ];
+
+  for (const { name, selector } of modules) {
+    test(`${name} module should load correctly`, async ({ page }) => {
+      const dashboard = new DashboardPage(page);
+      await dashboard.openModule(name);
+      const modulePage = new ModulePage(page, selector);
+      await modulePage.isLoaded();
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["tests/**/*.ts", "pages/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- expand module test coverage using a data-driven approach
- document default environment variables and updated module list

## Testing
- `npx playwright test` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_b_685a309c83c8832f8da798a576776f9a