### PR TITLE
Add detailed email link flow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,28 @@ This repository contains Playwright tests written in TypeScript for the UAPI app
    export UAPI_PASSWORD="V@iolaptop1234"
    ```
 
+3. (Optional) Configure email testing:
+   ```bash
+   export TEST_INBOX_ID="your-test-inbox"
+   export EMAIL_API_BASE_URL="https://api.example.com"
+   ```
+
 ## Running Tests
 
 Execute all tests using:
 ```bash
 npx playwright test
 ```
+
+## Testing Email Links
+
+Use a test inbox to capture emails sent by the application.
+The helper `getLatestEmailLink` in `utils/email.ts` illustrates how to retrieve
+the latest message and extract a link. Set `TEST_INBOX_ID` and optionally
+`EMAIL_API_BASE_URL` before running the test in `tests/emailFlow.spec.ts`.
+
+See [docs/email-flow.md](docs/email-flow.md) for a detailed step-by-step guide on
+setting up and running the email link flow test.
 
 ## Notes
 

--- a/docs/email-flow.md
+++ b/docs/email-flow.md
@@ -1,0 +1,57 @@
+# Email Link Flow with Playwright
+
+This guide explains how to test flows that rely on links sent via email. It assumes you have a test inbox that exposes an API for retrieving the latest message.
+
+## 1. Environment Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set the following environment variables:
+   ```bash
+   export UAPI_BASE_URL="https://qc.uapi.sa"
+   export UAPI_USERNAME="your-username"
+   export UAPI_PASSWORD="your-password"
+   export TEST_INBOX_ID="your-test-inbox"
+   export EMAIL_API_BASE_URL="https://api.example.com" # optional
+   ```
+   `TEST_INBOX_ID` points to the inbox where emails are sent. `EMAIL_API_BASE_URL` overrides the default email service URL used in `utils/email.ts`.
+
+## 2. Triggering the Email
+
+Use Playwright or a direct API request to perform the action that causes the application to send an email. This step is specific to your app. For example:
+
+```ts
+await page.click('button:has-text("Send Email")');
+```
+
+## 3. Retrieving the Link
+
+After triggering the email, call `getLatestEmailLink` from `utils/email.ts`:
+
+```ts
+import { getLatestEmailLink } from '../utils/email';
+
+const emailLink = await getLatestEmailLink(process.env.TEST_INBOX_ID!);
+```
+
+This helper fetches the latest message body from the configured inbox and extracts the first URL.
+
+## 4. Completing the Flow
+
+Navigate to the retrieved link and continue the test:
+
+```ts
+await page.goto(emailLink);
+// Perform assertions or further actions
+await expect(page).toHaveURL(/welcome/);
+```
+
+## 5. Troubleshooting
+
+- Ensure the email service is reachable from the test environment.
+- Check that the email is actually sent and contains a valid link.
+- Add logging (`console.log(emailLink)`) if the navigation fails.
+
+With these steps you can automate flows that involve links delivered by email.

--- a/tests/emailFlow.spec.ts
+++ b/tests/emailFlow.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { getLatestEmailLink } from '../utils/email';
+
+test.describe('Email link flow', () => {
+  test.skip(!process.env.TEST_INBOX_ID, 'No test inbox configured');
+
+  test('open link from email and complete flow', async ({ page }) => {
+    // Example: admin triggers email here (implementation specific)
+    const emailLink = await getLatestEmailLink(process.env.TEST_INBOX_ID!);
+
+    await page.goto(emailLink);
+    await expect(page).toHaveURL(/welcome/);
+  });
+});

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -1,0 +1,15 @@
+export async function getLatestEmailLink(inboxId: string): Promise<string> {
+  // Replace with your email service API. The base URL can be supplied via the
+  // EMAIL_API_BASE_URL environment variable.
+  const baseUrl = process.env.EMAIL_API_BASE_URL || 'https://api.example.com';
+  const response = await fetch(`${baseUrl}/inboxes/${inboxId}/latest`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch email: ${response.status}`);
+  }
+  const body = await response.text();
+  const match = body.match(/https?:\/\/\S+/);
+  if (!match) {
+    throw new Error('No link found in latest email');
+  }
+  return match[0];
+}


### PR DESCRIPTION
## Summary
- expand email testing instructions in README
- create `docs/email-flow.md` explaining the flow step by step

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_686684f1e2f4832f926c7f2901083e07